### PR TITLE
OpenTire Examples

### DIFF
--- a/code/setup.py
+++ b/code/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(
+    name='OpenTire',
+    version='0.1',
+    description='An open-source mathematical tire model library for tire and vehicle research and development.',
+    url='https://github.com/OpenTire/OpenTire',
+    author='OpenTire',
+    license='MIT',
+    packages=['opentire'],
+    zip_safe=False,
+    install_requires=['numpy'],
+    classifiers=[
+       'Programming Language :: Python :: 2'
+    ],
+)

--- a/code/setup.py
+++ b/code/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='OpenTire',
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/OpenTire/OpenTire',
     author='OpenTire',
     license='MIT',
-    packages=['opentire'],
+    packages=find_packages(),
     zip_safe=False,
     install_requires=['numpy'],
     classifiers=[

--- a/examples/FY_SA_Example.ipynb
+++ b/examples/FY_SA_Example.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Getting Started with OpenTire w/ Jupyter Notebook\n",
+    "============================\n",
+    "Generate a lateral force vs slip angle plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Import OpenTire and other libraries used in this demonstration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from opentire import OpenTire\n",
+    "from opentire.Core import TireState\n",
+    "from opentire.Core import TIRFile\n",
+    "\n",
+    "from pprint import pprint\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Initialize the OpenTire factory and create a Pacejka 2002 tire model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "openTire = OpenTire()\n",
+    "myTireModel = openTire.createmodel('PAC2002')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Initialize the tire state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "state = TireState()\n",
+    "\n",
+    "state['FZ'] = 1500\n",
+    "state['IA'] = 0.0\n",
+    "state['SR'] = 0.0\n",
+    "state['SA'] = 0.0\n",
+    "state['FY'] = 0.0\n",
+    "state['V'] = 10.0\n",
+    "state['P'] = 260000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Solving for the tire forces will update the tire state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "myTireModel.solve(state)\n",
+    "pprint(state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Iterate over vertical loads and slip angles to generate a lateral force vs slip angle plot at three different vertical loads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Setup the simulation range\n",
+    "vertical_loads = [500, 1000, 2000]\n",
+    "slip_angles = np.arange(-12, 12, 0.1) * 3.14 / 180\n",
+    "\n",
+    "# Initialize the lateral force result\n",
+    "lateral_force = []\n",
+    "\n",
+    "for fz in vertical_loads:\n",
+    "    lateral_force = []\n",
+    "    state['FZ'] = fz\n",
+    "    \n",
+    "    for sa in slip_angles:\n",
+    "        # Solving\n",
+    "        state['SA'] = sa\n",
+    "        myTireModel.solve(state)\n",
+    "        lateral_force.append(state['FY'])\n",
+    "\n",
+    "    # Plot the series\n",
+    "    plt.plot(slip_angles * 180 / 3.14, lateral_force, label=fz)\n",
+    "\n",
+    "# Plotting\n",
+    "plt.grid()\n",
+    "plt.xlabel('Slip Angle [deg]')\n",
+    "plt.ylabel('Lateral Force [N]')\n",
+    "plt.title('Lateral Force vs. Slip Angle')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Moment_Diagram_Example.ipynb
+++ b/examples/Moment_Diagram_Example.ipynb
@@ -1,0 +1,343 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "OpenTire Moment Method Example\n",
+    "=================\n",
+    "Draws a constant velocity force-moment diagram of a bicycle using the OpenTire library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Import OpenTire and other libraries used in this demonstration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from opentire import OpenTire\n",
+    "from opentire.Core import TireState\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Define the vehicle class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "class Vehicle():\n",
+    "    def __init__(self):\n",
+    "        self._mass = 1000\n",
+    "        self._wb = 1\n",
+    "        self._wd = 0.5\n",
+    "        self._ft = None\n",
+    "        self._rt = None\n",
+    "    \n",
+    "    @property\n",
+    "    def mass(self):\n",
+    "        return self._mass\n",
+    "    \n",
+    "    @mass.setter\n",
+    "    def mass(self, value):\n",
+    "        if value <= 0:\n",
+    "            raise ValueError('Mass must be greater than zero')\n",
+    "        self._mass = value\n",
+    "    \n",
+    "    @property\n",
+    "    def wheelbase(self):\n",
+    "        return self._wb\n",
+    "    \n",
+    "    @wheelbase.setter\n",
+    "    def wheelbase(self, value):\n",
+    "        if value <= 0:\n",
+    "            raise ValueError('Wheelbase must be greater than zero')\n",
+    "        self._wb = value\n",
+    "        \n",
+    "    @property\n",
+    "    def weight_dist(self):\n",
+    "        return self._wd\n",
+    "    \n",
+    "    @weight_dist.setter\n",
+    "    def weight_dist(self, value):\n",
+    "        if value >= 1 or value <= 0:\n",
+    "            raise ValueError('Weight distribution must be a ratio between 0 and 1')\n",
+    "        self._wd = value\n",
+    "        \n",
+    "    @property\n",
+    "    def front_tire(self):\n",
+    "        return self._ft\n",
+    "    \n",
+    "    @front_tire.setter\n",
+    "    def front_tire(self, value):\n",
+    "        if not isinstance(value, TireModelBase) and value is not None:\n",
+    "            raise TypeError('Front tire must be a OpenTire model')\n",
+    "        self._ft = value\n",
+    "        \n",
+    "    @property\n",
+    "    def rear_tire(self):\n",
+    "        return self._rt\n",
+    "    \n",
+    "    @front_tire.setter\n",
+    "    def rear_tire(self, value):\n",
+    "        if not isinstance(value, TireModelBase) and values is not None:\n",
+    "            raise TypeError('Rear tire must be a OpenTire model')\n",
+    "        self._rt = value\n",
+    "        \n",
+    "    @property\n",
+    "    def length_a(self):\n",
+    "        return self.wheelbase * (1 - self.weight_dist)\n",
+    "    \n",
+    "    @property\n",
+    "    def length_b(self):\n",
+    "        return self.wheelbase * self.weight_dist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Define the Moment Method class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "class MomentMethodSolver():\n",
+    "    def __init__(self):\n",
+    "        self._vehicle = None\n",
+    "        self._beta = np.linspace(-12, 12, 25) * 3.14 / 180\n",
+    "        self._delta = np.linspace(-12, 12, 25) * 3.14 / 180\n",
+    "        self._velocity = 36\n",
+    "    \n",
+    "    @property\n",
+    "    def vehicle(self):\n",
+    "        return self._vehicle\n",
+    "    \n",
+    "    @vehicle.setter\n",
+    "    def vehicle(self, value):\n",
+    "        if not isinstance(value, Vehicle) and value is not None:\n",
+    "            raise TypeError('Solver vehicle must be of Vehicle type')\n",
+    "        self._vehicle = value\n",
+    "        \n",
+    "    @property\n",
+    "    def beta_range(self):\n",
+    "        return self._beta\n",
+    "    \n",
+    "    @beta_range.setter\n",
+    "    def beta_range(self, value):\n",
+    "        self._beta = value\n",
+    "        \n",
+    "    @property\n",
+    "    def delta_range(self):\n",
+    "        return self._delta\n",
+    "    \n",
+    "    @delta_range.setter\n",
+    "    def delta_range(self, value):\n",
+    "        self._delta = value   \n",
+    "    \n",
+    "    @property\n",
+    "    def velocity(self):\n",
+    "        return self._velocity\n",
+    "    \n",
+    "    @velocity.setter\n",
+    "    def velocity(self, value):\n",
+    "        self._velocity = value\n",
+    "    \n",
+    "    def solve(self):\n",
+    "        fy = np.empty([len(self.beta_range), len(self.delta_range)])\n",
+    "        mz = np.empty([len(self.beta_range), len(self.delta_range)])\n",
+    "        initial_guess = (0, 0)\n",
+    "        \n",
+    "        for i, beta in enumerate(self.beta_range):\n",
+    "            for j, delta in enumerate(self.delta_range):\n",
+    "                # Use previous solution as a guess\n",
+    "                if j > 0: initial_guess = self._invertSolution(fy[i][j-1], mz[i][j-1])\n",
+    "                elif i > 0: initial_guess = self._invertSolution(fy[i-1][j], mz[i-1][j])\n",
+    "                else: initial_guess = (0, 0)\n",
+    "                \n",
+    "                result = self._solve(beta, delta, initial_guess)\n",
+    "                fy[i][j] = result[0]\n",
+    "                mz[i][j] = result[1]\n",
+    "                \n",
+    "        return (fy, mz)\n",
+    "    \n",
+    "    def _solve(self, beta, delta, initial_guess = (0, 0)):\n",
+    "        state = TireState()\n",
+    "        state['FZ'] = 1500\n",
+    "        state['IA'] = 0.0\n",
+    "        state['SR'] = 0.0\n",
+    "        state['SA'] = 0.0\n",
+    "        state['FY'] = 0.0\n",
+    "        state['V'] = 10.0\n",
+    "        state['P'] = 260000\n",
+    "        \n",
+    "        MAX_ITER = 100\n",
+    "        n = 0\n",
+    "        error = 9999\n",
+    "        tolerance = 0.1\n",
+    "        yaw_velocity = 0\n",
+    "        \n",
+    "        front_force = initial_guess[0]\n",
+    "        rear_force = initial_guess[1]\n",
+    "        \n",
+    "        while (n < MAX_ITER and abs(error) > tolerance):            \n",
+    "            # Yaw rate\n",
+    "            yaw_velocity = (front_force + rear_force) / (self.vehicle.mass * self.velocity)\n",
+    "            error = front_force + rear_force\n",
+    "            \n",
+    "            # Slip Angles\n",
+    "            sa_front = beta - delta + yaw_velocity * self.vehicle.length_a / self.velocity\n",
+    "            sa_rear = beta - yaw_velocity * self.vehicle.length_b / self.velocity\n",
+    "\n",
+    "            # Front Tire\n",
+    "            state['SA'] = sa_front\n",
+    "            state['FZ'] = 0.5 * 9.81 * self.vehicle.mass * self.vehicle.weight_dist\n",
+    "            self.vehicle.front_tire.solve(state)\n",
+    "\n",
+    "            front_force = state['FY']\n",
+    "            state['SA'] = -sa_front\n",
+    "            self.vehicle.front_tire.solve(state)\n",
+    "            front_force -= state['FY']\n",
+    "\n",
+    "            # Rear Tire\n",
+    "            state['SA'] = sa_rear\n",
+    "            state['FZ'] = 0.5 * 9.81 * self.vehicle.mass * (1 - self.vehicle.weight_dist)\n",
+    "            self.vehicle.rear_tire.solve(state)\n",
+    "\n",
+    "            rear_force = state['FY']\n",
+    "            state['SA'] = -sa_rear\n",
+    "            self.vehicle.rear_tire.solve(state)\n",
+    "            rear_force -= state['FY']\n",
+    "            \n",
+    "            error -= front_force + rear_force\n",
+    "            n += 1\n",
+    "            \n",
+    "        return (front_force + rear_force,\n",
+    "                front_force * self.vehicle.length_a - rear_force * self.vehicle.length_b)\n",
+    "    \n",
+    "    def _invertSolution(self, lateral_force, yaw_moment):\n",
+    "        front_force = (1 / (self.vehicle.length_a + self.vehicle.length_b)) * (self.vehicle.length_b * lateral_force\n",
+    "                                                                               + yaw_moment)\n",
+    "        rear_force = (1 / (self.vehicle.length_a + self.vehicle.length_b)) * (self.vehicle.length_a * lateral_force \n",
+    "                                                                              - yaw_moment)\n",
+    "            \n",
+    "        return (front_force, rear_force)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Run simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "openTire = OpenTire()\n",
+    "\n",
+    "myVehicle = Vehicle()\n",
+    "myVehicle.mass = 1250  # kg\n",
+    "myVehicle.wheelbase = 2.4  # m\n",
+    "myVehicle.weight_dist = 0.47  # ratio\n",
+    "myVehicle.front_tire = openTire.createmodel('PAC2002')\n",
+    "myVehicle.rear_tire = openTire.createmodel('PAC2002')\n",
+    "\n",
+    "solver = MomentMethodSolver()\n",
+    "solver.vehicle = myVehicle\n",
+    "solver.beta = np.linspace(-15, 16, 31) * 3.14 / 180\n",
+    "solver.delta = np.linspace(-15, 16, 31) * 3.14 / 180\n",
+    "solver.velocity = 70 / 3.6\n",
+    "\n",
+    "force_moments = solver.solve()\n",
+    "lateral_accel = force_moments[0] / myVehicle.mass / 9.81\n",
+    "yaw_moment = force_moments[1]\n",
+    "\n",
+    "plt.plot(lateral_accel[:][:], yaw_moment[:][:], color='black')\n",
+    "plt.plot(np.transpose(lateral_accel[:][:]), np.transpose(yaw_moment[:][:]), color='red')\n",
+    "\n",
+    "plt.grid()\n",
+    "plt.xlabel(\"Lateral Acceleration [g]\")\n",
+    "plt.ylabel(\"Yaw Moment [Nm]\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/SA_Sweep_Example.py
+++ b/examples/SA_Sweep_Example.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+from opentire import OpenTire
+from opentire.Core import TireState
+from opentire.Core import TIRFile
+
+import numpy as np
+
+if __name__ == "__main__":
+
+    # Initialize the tire model
+    openTire = OpenTire()
+    myTireModel = openTire.createmodel('PAC2002')
+
+    # Initialize the tire state
+    state = TireState()
+    state['FZ'] = 1500
+    state['IA'] = 0.0
+    state['SR'] = 0.0
+    state['SA'] = 0.0
+    state['FY'] = 0.0
+    state['V'] = 10.0
+    state['P'] = 260000
+
+    # Define the slip angle range
+    slip_angles = np.arange(-12, 13, 1) * 3.14 / 180
+
+    # Print out some pretty formatting
+    print('OpenTire Slip Angle Sweep Demo\n')
+    print('{0:>10} | {1:>10} | {2:>10} | {3:>10} | {4:>10}'
+          .format('SA [deg]',
+                  'FZ [N]',
+                  'FY [N]',
+                  'MZ [Nm]',
+                  'MX [Nm]'))
+    print('=' * 62)
+
+    # Calculate and print out the tire model outputs
+    for sa in slip_angles:
+        state['SA'] = sa
+        myTireModel.solve(state)
+        print('{0:>10.0f} | {1:>10.0f} | {2:>10.1f} | {3:>10.1f} | {4:>10.1f}'
+              .format(state['SA'] * 180 / 3.14,
+                      state['FZ'],
+                      state['FY'],
+                      state['MZ'],
+                      state['MX']))
+


### PR DESCRIPTION
A few demo scripts showing how OpenTire could be used. Includes a basic slip angle sweep, a FY vs. SA plot and a simple moment diagram. The slip angle sweep and moment diagram are in a Jupyter notebook.

The examples are dependent on pull request #8 since it treats OpenTire as a module.